### PR TITLE
Fix plural on display

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -85,7 +85,7 @@ chrome.storage.local.get("hostNavigationStats", function(results) {
       }
 
       // Display plural
-      if (elapsedTime > 1) {
+      if (displayTime > 1) {
         displayUnit = displayUnit + 's';
       }
 


### PR DESCRIPTION
There is a small typo on the time unit showing a plural when there is only 1 unit.
This is fixed by using the correct variable.